### PR TITLE
chore(ci): update workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: ivuorinen/actions/pr-lint@877acc6d8b013051a6acf83c0e876d3a2b46210a # v2026.06.08
+      - uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
 
   LintPR:
     if: github.event_name == 'pull_request'
@@ -28,4 +28,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: ivuorinen/actions/pr-lint@877acc6d8b013051a6acf83c0e876d3a2b46210a # v2026.06.08
+      - uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: ivuorinen/actions/pr-lint@84380fe01733b915ffea5892083ee636ed2b765a # v2026.05.04
+      - uses: ivuorinen/actions/pr-lint@877acc6d8b013051a6acf83c0e876d3a2b46210a # v2026.06.08
 
   LintPR:
     if: github.event_name == 'pull_request'
@@ -28,4 +28,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: ivuorinen/actions/pr-lint@84380fe01733b915ffea5892083ee636ed2b765a # v2026.05.04
+      - uses: ivuorinen/actions/pr-lint@877acc6d8b013051a6acf83c0e876d3a2b46210a # v2026.06.08

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: ivuorinen/actions/stale@877acc6d8b013051a6acf83c0e876d3a2b46210a # v2026.06.08
+      - uses: ivuorinen/actions/stale@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: ivuorinen/actions/stale@84380fe01733b915ffea5892083ee636ed2b765a # v2026.05.04
+      - uses: ivuorinen/actions/stale@877acc6d8b013051a6acf83c0e876d3a2b46210a # v2026.06.08


### PR DESCRIPTION
This pull request updates GitHub Actions workflow dependencies to newer versions for improved stability and security. The changes primarily involve bumping the versions of third-party action dependencies in workflow YAML files.

Dependency updates:

* Updated `actions/checkout` from version `v6.0.2` to `v6.0.3` in `.github/workflows/lint.yml` to use the latest patch release.
* Updated `ivuorinen/actions/pr-lint` from `v2026.05.04` to `v2026.06.08` in two places within `.github/workflows/pr-lint.yml`. [[1]](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dL20-R20) [[2]](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dL31-R31)
* Updated `ivuorinen/actions/stale` from `v2026.05.04` to `v2026.06.08` in `.github/workflows/stale.yml`.